### PR TITLE
Add warning to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # borgbackup on android
+
+*Note: This process is no longer necessary, simply run `pkg install borgbackup` in Termus*
+
 This project provides build scripts to compile borgbackup (https://github.com/borgbackup/borg) and its dependencies on Android. It uses termux (https://termux.com/) as a lightweight environment. 
 
 Yoou don't root permission on your phone to use it. However without root permissions the access to data of other apps or system data is not possible, but you can still access your photos, videos,...


### PR DESCRIPTION
This adds a warning to the README explaining that BorgBackup is available and working straight from the repos in Termux. Otherwise, people (like me) might come across this repo and assume that this is the easiest way.